### PR TITLE
Fixes #5: Adds loading of developer certificates into the script, write to the file

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -21,3 +21,28 @@ CONFIG_FILE=$CONFIG_FILE_NAME.xcconfig
 && cp -n Local.templates/$CONFIG_FILE Local/$CONFIG_FILE \
 )
 done
+
+echo "Choose your developer team that you wish to sign DevSwitch with:"
+IFS=$'\n'
+developerids=($(security find-identity -v -p codesigning | awk '!/CSSMERR_TP_CERT_REVOKE|Mac/' | awk -F \" '{if ($2) print $2}'))
+
+select opt in "${developerids[@]}" "Quit"
+do
+    if [[ "$opt" == "Quit" ]]; then 
+      echo "Bye!"
+      break; 
+    fi
+
+    # complain if an invalid option was chosen
+    if [[ "$opt" == "" ]]
+    then
+        echo "'$REPLY' is not a valid option"
+        continue
+    fi
+
+    # now we can use the selected option
+    identifier=`echo $opt | awk -F '[\(\)]' '{print $2}'`
+    sed -i '' -e "s:LOCAL_DEVELOPMENT_TEAM = \/:LOCAL_DEVELOPMENT_TEAM = $identifier \/:g" "$CONFIG_PATH/Local/DevTeam.xcconfig"
+    echo "You selected '$opt' as your developer team, we've written this to '$CONFIG_PATH/Local/DevTeam.xcconfig'"
+    break
+done


### PR DESCRIPTION
Basic concept of filling in the file using AWK and security per @shpakovski's suggestion.

No error checking if `sed`'s replacement call works currently, but it does aid with setup. Also no checks if you haven't already setup before.